### PR TITLE
Add readme test to tesla api public key location

### DIFF
--- a/.well-known/appspecific/readme.md
+++ b/.well-known/appspecific/readme.md
@@ -1,0 +1,1 @@
+This is the location where the Tesla Fleet API requires the public key to be hosted from


### PR DESCRIPTION
Releasing a test readme in the same location as the eventual public key for my tesla fleet api public key